### PR TITLE
Added the --ignore-tag-errors flag for lame

### DIFF
--- a/flac2mp3
+++ b/flac2mp3
@@ -23,4 +23,4 @@ end
 basename = File.basename(filename, File.extname(filename))
 
 puts "Encoding #{basename}.mp3"
-exec %Q[flac -sdc "#{filename}" | lame -#{qualarg} #{args} - "#{basename}.mp3"]
+exec %Q[flac -sdc "#{filename}" | lame --ignore-tag-errors -#{qualarg} #{args} - "#{basename}.mp3"]


### PR DESCRIPTION
Hi,

I added the --ignore-tag-errors flag to prevent lame from blowing up on weird tags. It was helpful for me.
